### PR TITLE
Fix Phone Number Regex 

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone implements Comparable<Phone> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should start with 6, 8, or 9 and be 3 or 8 digits long\"";
+    public static final String VALIDATION_REGEX = "[689](\\d{2}|\\d{7})";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,7 +11,7 @@ public class Phone implements Comparable<Phone> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should start with 6, 8, or 9 and be 3 or 8 digits long\"";
+            "Phone numbers should start with 6, 8, or 9 and be 3 or 8 digits long";
     public static final String VALIDATION_REGEX = "[689](\\d{2}|\\d{7})";
     public final String value;
 

--- a/src/test/data/JsonDatabaseStorageTest/invalidAndValidAppointmentDatabase.json
+++ b/src/test/data/JsonDatabaseStorageTest/invalidAndValidAppointmentDatabase.json
@@ -1,12 +1,12 @@
 {
   "patients": [ {
     "name": "Valid Patient",
-    "phone": "9482424",
+    "phone": "94824245",
     "nric": "T0123456F"
   } ],
   "doctors": [ {
     "name": "Valid Doctor",
-    "phone": "9482424",
+    "phone": "94824245",
     "nric": "S6543210Z"
   } ],
   "appointments": [ {

--- a/src/test/data/JsonDatabaseStorageTest/invalidAndValidPatientDatabase.json
+++ b/src/test/data/JsonDatabaseStorageTest/invalidAndValidPatientDatabase.json
@@ -1,7 +1,7 @@
 {
   "patients": [ {
     "name": "Valid Patient",
-    "phone": "9482424",
+    "phone": "94824245",
     "nric": "T0123456F"
   }, {
     "name": "Person With Invalid Phone Field",

--- a/src/test/data/JsonDatabaseStorageTest/invalidPatientDatabase.json
+++ b/src/test/data/JsonDatabaseStorageTest/invalidPatientDatabase.json
@@ -1,7 +1,7 @@
 {
   "patients": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
+    "phone": "94824245",
     "nric": "T0123456F"
   } ],
   "doctors": [],

--- a/src/test/data/JsonSerializableDatabaseTest/invalidPatientDatabase.json
+++ b/src/test/data/JsonSerializableDatabaseTest/invalidPatientDatabase.json
@@ -1,7 +1,7 @@
 {
   "patients": [ {
     "name": "Hans Muster",
-    "phone": "9482424",
+    "phone": "94824245",
     "nric": "X6543210P",
     "remark": "",
     "tags": []

--- a/src/test/data/JsonSerializableDatabaseTest/typicalDatabase.json
+++ b/src/test/data/JsonSerializableDatabaseTest/typicalDatabase.json
@@ -27,19 +27,19 @@
   }, {
     "nric" : "G4123573C",
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "94822244",
     "remark": "",
     "tags": []
   }, {
     "nric" : "G6739542H",
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "94824278",
     "remark": "",
     "tags": []
   }, {
     "nric" : "T0359320R",
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "94824425",
     "remark": "",
     "tags": []
   } ],

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_NRIC = "A1234567N";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "81234567";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPatientPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPatientPredicateTest.java
@@ -83,8 +83,8 @@ public class NameContainsKeywordsPatientPredicateTest {
         assertFalse(predicate.test(new PatientBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, but does not match name
-        predicate = new NameContainsKeywordsPatientPredicate(Arrays.asList("12345"));
-        assertFalse(predicate.test(new PatientBuilder().withName("Alice").withPhone("12345").build()));
+        predicate = new NameContainsKeywordsPatientPredicate(Arrays.asList("81234567"));
+        assertFalse(predicate.test(new PatientBuilder().withName("Alice").withPhone("81234567").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -35,7 +35,6 @@ public class PhoneTest {
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPatient.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatient.java
@@ -42,24 +42,24 @@ public class TypicalPatient {
     public static final Patient DANIEL = new PatientBuilder().withName(PersonUtil.DANIEL_NAME).withPhone(DANIEL_PHONE)
             .withNric(PersonUtil.DANIEL_NRIC).build();
 
-    public static final String ELLE_PHONE = "9482224";
+    public static final String ELLE_PHONE = "94822244";
     public static final Patient ELLE = new PatientBuilder().withName(PersonUtil.ELLE_NAME).withPhone(ELLE_PHONE)
             .withNric(PersonUtil.ELLE_NRIC).build();
 
-    public static final String FIONA_PHONE = "9482427";
+    public static final String FIONA_PHONE = "94824278";
     public static final Patient FIONA = new PatientBuilder().withName(PersonUtil.FIONA_NAME).withPhone(FIONA_PHONE)
             .withNric(PersonUtil.FIONA_NRIC).build();
 
-    public static final String GEORGE_PHONE = "9482442";
+    public static final String GEORGE_PHONE = "94824425";
     public static final Patient GEORGE = new PatientBuilder().withName(PersonUtil.GEORGE_NAME).withPhone(GEORGE_PHONE)
             .withNric(PersonUtil.GEORGE_NRIC).build();
 
-    public static final String HOON_PHONE = "8482424";
+    public static final String HOON_PHONE = "84824245";
     // Manually added
     public static final Patient HOON = new PatientBuilder().withName(PersonUtil.HOON_NAME).withPhone(HOON_PHONE)
             .withNric(PersonUtil.HOON_NRIC).build();
 
-    public static final String IDA_PHONE = "8482131";
+    public static final String IDA_PHONE = "84821315";
     public static final Patient IDA = new PatientBuilder().withName(PersonUtil.IDA_NAME).withPhone(IDA_PHONE)
             .withNric(PersonUtil.IDA_NRIC).build();
 


### PR DESCRIPTION
Closes #196 

Make it become more restrictive that phone numbers should start with 6, 8, or 9 and be 3 or 8 digits long. eg: 911, 81754211
